### PR TITLE
Improve language switcher position across screen sizes

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,6 @@
 <!-- Fixed navbar -->
 <nav class="navbar navbar-custom navbar-static-top">
   <div class="container">
-
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
         <span class="sr-only">Toggle navigation</span>
@@ -9,6 +8,31 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
+    {% assign langmenu = true %}
+    {% if page.layout == nil or page.collection == 'posts' %}
+      <!-- no translation for news -->
+      {% assign langmenu = false %}
+      {% assign archies = site.data.architecture %}
+    {% else %}
+      {% if page.lang == nil or page.lang == "en" %}
+        {% assign archies = site.data.architecture %}
+      {% else %}
+        {% assign archies = site.data.translation[page.lang].architecture %}
+        {% if archies == nil or archies.size == 0 %}
+          {% assign archies = site.data.architecture %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+    {% if langmenu %}
+      {% assign posts = site.pages | concat: site.doc | concat: site.qubes-translated | where:'ref', page.ref | sort: 'lang' %}
+      <div class="langdropdown langdropdown-sm">
+        <span><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></span>
+        <div class="langdropdown-items">
+          {% for post in posts %}
+          <a class="c1" href="{{ post.url }}">{{ post.lang }}</a>
+          {% endfor %}
+        </div>
+      </div>
       <a class="page-link" href="/">
         <img src="/attachment/icons/128x128/apps/qubes-logo-icon.png" width="44" height="44" alt="Qubes OS Project">
         <span><strong>Qubes</strong> OS</span>
@@ -16,43 +40,23 @@
     </div>
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav nav-justified">
-
-	 {% assign langmenu = true %}
-	 {% if page.layout == nil or page.collection == 'posts' %}
-         <!-- no translation for news -->
-	  		{% assign langmenu = false %}
-          	{% assign archies = site.data.architecture %}
-     {% else %}
-         	{% if page.lang == nil or page.lang == "en" %}
-				{% assign archies = site.data.architecture %}
-			{% else %}
-				{% assign archies = site.data.translation[page.lang].architecture %}
-				{% if archies == nil or archies.size == 0 %}
-                  {% assign archies = site.data.architecture %}
-            	{% endif %}
-			{% endif %}
-
-	 {% endif %}
-     {% for section in archies %}
-            <li id="nav-button-{{ section.title | slugify }}">
-             <a href="{{ section.url }}">{{ section.title }}</a>
-            </li>
-     {% endfor %}
-	 {% if langmenu %}
-          {% assign posts = site.pages | concat: site.doc | concat: site.qubes-translated | where:'ref', page.ref | sort: 'lang' %}
-		  <li>
-		   <div class="langdropdown">
-		     <span><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></span>
-		     <div class="langdropdown-items">
-		       {% for post in posts %}
-			 	<a class="c1" href="{{ post.url }}">{{ post.lang }}</a>
-		       {% endfor %}
-		     </div>
-		   </div>
-		 </li>
-	 {% endif %}
-
+        {% for section in site.data.architecture %}
+        <li id="nav-button-{{ section.title | slugify }}">
+          <a href="{{ section.url }}">{{ section.title }}</a>
+        </li>
+        {% endfor %}
+        <li id="nav-button-lang-switch">
+          <div class="langdropdown langdropdown-lg">
+            <span><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></span>
+            <div class="langdropdown-items">
+              {% for post in posts %}
+              <a class="c1" href="{{ post.url }}">{{ post.lang }}</a>
+              {% endfor %}
+            </div>
+          </div>
+        </li>
       </ul>
+    {% endif %}
     </div><!--/.nav-collapse -->
   </div>
 </nav>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,8 +26,9 @@
     {% if langmenu %}
       {% assign posts = site.pages | concat: site.doc | concat: site.qubes-translated | where:'ref', page.ref | sort: 'lang' %}
       <div class="langdropdown langdropdown-sm">
-        <span><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></span>
-        <div class="langdropdown-items">
+        <label class="langdropbtn-sm" for="langdropdown-toggle-sm"><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></label>
+        <input type="checkbox" id="langdropdown-toggle-sm">
+        <div class="langdropdown-content" id="langdropdown-dd-sm">
           {% for post in posts %}
           <a class="c1" href="{{ post.url }}">{{ post.lang }}</a>
           {% endfor %}
@@ -47,8 +48,9 @@
         {% endfor %}
         <li id="nav-button-lang-switch">
           <div class="langdropdown langdropdown-lg">
-            <span><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></span>
-            <div class="langdropdown-items">
+            <label class="langdropbtn-lg" for="langdropdown-toggle-lg"><img src="/attachment/icons/icons8-translation-64.png" width="24" height="24"></label>
+            <input type="checkbox" id="langdropdown-toggle-lg">
+            <div class="langdropdown-content" id="langdropdown-dd-lg">
               {% for post in posts %}
               <a class="c1" href="{{ post.url }}">{{ post.lang }}</a>
               {% endfor %}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -87,14 +87,18 @@
   }
 
   // Language Switcher
-  .langdropdown-lg {
-    position: relative;
-    display: inline-block;
+  .langdropbtn-lg {
+    border: none;
     padding: 10px 15px;
     margin-left: 25px;
   }
 
-  .langdropdown-items {
+  .langdropdown-lg {
+    position: relative;
+    display: inline-block;
+  }
+
+  .langdropdown-content {
     display: none;
     position: absolute;
     text-align: center;
@@ -102,6 +106,7 @@
     border: 1px solid $gray-light;
     margin-top: 5px;
     padding: 10px;
+    z-index: 1;
     a {
       color: $gray-base;
       font-family: $ostrich-heavy;
@@ -110,14 +115,35 @@
     }
   }
 
-  .langdropdown:hover .langdropdown-items {
+  .langdropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
     display: block;
+  }
+
+  /* .dropdown:hover .dropdown-content {display: block;} */
+  /* display the element with ID `dd` which is a sibling of the (checked) checkbox with ID `toggle` */
+  #langdropdown-toggle-lg:checked ~ #langdropdown-dd-lg {
+    display: block;
+  }
+
+  .langdropdown:hover .langdropbtn-lg {
+    background-color: $gray-light;
+    border-radius: $base-radius;
+  }
+
+  /* "hide" the checkbox (`display: none` doesn't work everwhere properly) */
+  #langdropdown-toggle-lg {
+    position: absolute;
+    top: -10000vh;
+    left: -10000vw;
+    opacity: 0;
   }
 
   .langdropdown-sm {
     display: none;
   }
-
 
 }
 
@@ -154,28 +180,6 @@
       }
     }
 
-    .langdropdown-sm {
-      display: block;
-      position: relative;
-      float: right;
-      margin-right: 15px;
-      margin-top: 5px;
-      margin-bottom: 11px;
-      padding: 9px 10px;
-    }
-
-    .langdropdown-items {
-      display: none;
-    }
-
-    .langdropdown:hover .langdropdown-items {
-      display: block;
-    }
-
-    .langdropdown-lg {
-      display: none;
-    }
-
     .navbar-collapse {
       position: relative;
       top: 10px;
@@ -195,6 +199,44 @@
           background-color: $gray-light;
         }
       }
+    }
+
+    // Language Switcher
+    .langdropbtn-sm {
+      border: none;
+      padding: 9px 10px;
+      margin-right: 15px;
+      margin-top: 3px;
+      margin-bottom: 8px;
+    }
+
+    .langdropdown-sm {
+      position: relative;
+      display: inline-block;
+      float: right;
+    }
+
+    /* .dropdown:hover .dropdown-content {display: block;} */
+    /* display the element with ID `dd` which is a sibling of the (checked) checkbox with ID `toggle` */
+    #langdropdown-toggle-sm:checked ~ #langdropdown-dd-sm {
+      display: block;
+    }
+
+    .langdropdown:hover .langdropbtn-sm {
+      background-color: $gray-light;
+      border-radius: $base-radius;
+    }
+
+    /* "hide" the checkbox (`display: none` doesn't work everwhere properly) */
+    #langdropdown-toggle-sm {
+      position: absolute;
+      top: -10000vh;
+      left: -10000vw;
+      opacity: 0;
+    }
+
+    .langdropdown-lg {
+      display: none;
     }
   }
 }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -85,6 +85,40 @@
       background-color: $gray-darker;
     }
   }
+
+  // Language Switcher
+  .langdropdown-lg {
+    position: relative;
+    display: inline-block;
+    padding: 10px 15px;
+    margin-left: 25px;
+  }
+
+  .langdropdown-items {
+    display: none;
+    position: absolute;
+    text-align: center;
+    background-color: $gray-lighter;
+    border: 1px solid $gray-light;
+    margin-top: 5px;
+    padding: 10px;
+    a {
+      color: $gray-base;
+      font-family: $ostrich-heavy;
+      font-size: 21px;
+      padding: 10px;
+    }
+  }
+
+  .langdropdown:hover .langdropdown-items {
+    display: block;
+  }
+
+  .langdropdown-sm {
+    display: none;
+  }
+
+
 }
 
 /* Makes links not wrap */
@@ -96,6 +130,10 @@
         padding: 10px 5px;
         letter-spacing: 0px;
       }
+    }
+    .langdropdown-lg {
+      padding: 10px 5px;
+      margin-left: 15px;
     }
   }
 }
@@ -114,6 +152,28 @@
         left: 15px;
         display: inline-block;
       }
+    }
+
+    .langdropdown-sm {
+      display: block;
+      position: relative;
+      float: right;
+      margin-right: 15px;
+      margin-top: 5px;
+      margin-bottom: 11px;
+      padding: 9px 10px;
+    }
+
+    .langdropdown-items {
+      display: none;
+    }
+
+    .langdropdown:hover .langdropdown-items {
+      display: block;
+    }
+
+    .langdropdown-lg {
+      display: none;
     }
 
     .navbar-collapse {

--- a/css/main.scss
+++ b/css/main.scss
@@ -178,45 +178,6 @@ article tr.center {
     }
 }
 
-
-// Custom - Language Dropdown Menu
-.langdropdown {
-    position: relative;
-    display: inline-block;
-}
-
-.langdropdown-items {
-    display: none;
-    position: absolute;
-    min-width: 100%;
-    z-index: 1;
-    overflow: auto;
-    right: 0;
-}
-
-.langdropdown:hover .langdropdown-items {
-    display: block;
-}
-
-@media only screen and (max-width: 400px) {
-  .langdropdown {
-    display: grid;
-    position: static;
-    text-align: center;
-  }
-
-  .langdropdown-items {
-    display: block;
-    position: static;
-    text-align: center;
-  }
-
-  .langdropdown:hover .langdropdown-items {
-    display: grid;
-  }
-}
-
-
 // Custom - Buttons
 .page-source-side,
 .download-content {


### PR DESCRIPTION
On large screens, the language switcher will be at the top right of the
page, after the last button in the nav bar ("Donate"). On small screens,
the language switcher will be immediately to the left of the nav menu
collapse toggle (hamburger menu). This commit also improves the font and
spacing of the language items within the menu.

CC: @tokideveloper, @maiska, @marmarek, @marmarta